### PR TITLE
ci: add GitHub Actions workflow for continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Elixir CI
+
+on:
+  push:
+    branches: [ "main", "develop" ]
+  pull_request:
+    branches: [ "main", "develop" ]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test-latest:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            elixir-version: '1.18.4'
+            otp-version: '28.0.1'
+
+    name: Build and test on ${{ matrix.os }} ${{ matrix.elixir-version }} ${{ matrix.otp-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Elixir
+      uses: erlef/setup-beam@e6d7c94229049569db56a7ad5a540c051a010af9
+      id: setup-beam
+      with:
+        elixir-version: ${{ matrix.elixir-version }}
+        otp-version: ${{ matrix.otp-version }}
+    - name: Install dependencies
+      run: mix deps.get
+    - name: Check format
+      run: mix format --check-formatted --migrate
+    - name: Check by nstandard
+      run: mix check
+    - name: Check documents
+      run: mix docs --warning-as-errors
+    - name: Run tests
+      run: mix test


### PR DESCRIPTION
This commit adds a comprehensive CI/CD pipeline for the CrandallReduction project:

Changes:

.github/workflows/ci.yml:
- Added GitHub Actions workflow for Elixir CI
- Configured to run on push to main/develop branches and pull requests
- Excludes documentation-only changes from triggering CI
- Uses Ubuntu 22.04 with Elixir 1.18.4 and OTP 28.0.1
- Implements concurrency control to cancel in-progress jobs
- Includes comprehensive build and test steps:
  - Dependency installation with mix deps.get
  - Code formatting check with mix format --check-formatted --migrate
  - Code quality check with mix check
  - Documentation generation with mix docs --warning-as-errors
  - Test execution with mix test
- Sets 5-minute timeout for jobs
- Uses erlef/setup-beam action for Elixir/OTP setup

Impact:
The CI pipeline ensures code quality, formatting consistency, documentation completeness, and test reliability. It provides automated validation for all contributions and maintains project standards across different environments.